### PR TITLE
Clean up Gradle build configuration and fix broken uberjar target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `make uberjar` (and the documented `./gradlew uberjar` command) was broken — no such task exists. Pointed `make uberjar` at `./gradlew buildFatJar` and updated `CLAUDE.md` / `llms.txt` accordingly.
+
+### Changed
+
+- Switched fat-jar configuration to Ktor's idiomatic `ktor { fatJar { archiveFileName = "server.jar" } }` block. `tasks.shadowJar` now only carries signature/license excludes (`META-INF/*.SF`, `*.DSA`, `*.RSA`, `LICENSE*`), collapsed into a single varargs `exclude(...)` call. This reverses the 1.7.0 consolidation toward `tasks.shadowJar` and removes parallel configuration paths.
+- Promoted `jvm` (17) and `gradle` (9.5.0) versions into `gradle/libs.versions.toml`. `build.gradle.kts` reads the JVM toolchain via `libs.versions.jvm.get().toInt()`; the `Makefile`'s `upgrade-wrapper` target reads the Gradle version from the catalog via `sed`.
+- Renamed the version-catalog plugin alias `versions` → `ben-manes-versions` (the prior name collided with the `[versions]` table). Call site is now `alias(libs.plugins.ben.manes.versions)`.
+- Extracted repeated `"clean"` / `"build"` task-name strings to `cleanTask` / `buildTask` references in `build.gradle.kts`.
+
 ## [1.7.0] - 2026-05-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ ReadingBat Template — a Kotlin/Ktor-based template for teachers to author Read
 - **Run all tests:** `./gradlew --rerun-tasks check` or `make tests`
 - **Run a single test class:** `./gradlew test --tests "ContentTests"`
 - **Run a single test:** `./gradlew test --tests "ContentTests.Test all challenges"`
-- **Build fat JAR:** `./gradlew uberjar` (outputs `build/libs/server.jar`)
+- **Build fat JAR:** `./gradlew buildFatJar` or `make uberjar` (outputs `build/libs/server.jar`)
 - **Check dependency updates:** `./gradlew dependencyUpdates` (default Make target)
 - **Continuous compile:** `make cc` (rebuilds on file changes, skips tests)
 
@@ -52,11 +52,13 @@ Managed in `gradle/libs.versions.toml`:
 - `readingbat-core` / `readingbat-kotest` — core DSL, server, and test framework (Maven Central)
 - Ktor — web server framework
 - Kotest — test framework (JUnit5 runner)
-- JVM toolchain: Java 17
+- `jvm` and `gradle` versions are also tracked in the catalog. `build.gradle.kts` reads `libs.versions.jvm.get().toInt()` for the toolchain; the `Makefile` reads `gradle` from the catalog for `upgrade-wrapper`.
 
 Test dependencies are exposed as a `[bundles] testing` entry and consumed in `build.gradle.kts` via `libs.bundles.testing`.
 
 `group` and `version` live in `gradle.properties` (not `build.gradle.kts`). Repository configuration lives in `settings.gradle.kts` with `FAIL_ON_PROJECT_REPOS` enforcement — do not add per-project repositories to `build.gradle.kts`.
+
+Fat-jar output (`build/libs/server.jar`) is configured via the `ktor { fatJar { archiveFileName = ... } }` block; `tasks.shadowJar` only carries signature/license excludes. Build it with `./gradlew buildFatJar` (or `make uberjar`).
 
 ## DSL Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default clean build tests uberjar uber cc run heroku logs versioncheck upgrade-wrapper
 
+GRADLE_VERSION := $(shell sed -n 's/^gradle = "\(.*\)"/\1/p' gradle/libs.versions.toml)
+
 default: versioncheck
 
 clean:
@@ -12,7 +14,7 @@ tests:
 	./gradlew --rerun-tasks check
 
 uberjar:
-	./gradlew uberjar
+	./gradlew buildFatJar
 
 uber: uberjar
 	java -jar build/libs/server.jar
@@ -33,4 +35,4 @@ versioncheck:
 	./gradlew dependencyUpdates
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,29 @@
 # Release Notes
 
+## Unreleased
+
+Build-housekeeping follow-ups to 1.7.0. No DSL or runtime behavior changes.
+
+### Highlights
+
+- **Fixed broken fat-jar make target.** `make uberjar` (and the previously documented `./gradlew uberjar`) referenced a task that does not exist. The Makefile now invokes `./gradlew buildFatJar`; `CLAUDE.md` and `llms.txt` updated to match.
+- **Single fat-jar configuration path.** Switched to Ktor's idiomatic `ktor { fatJar { archiveFileName = "server.jar" } }` block; `tasks.shadowJar` now only carries the META-INF signature/license excludes. Reverses the 1.7.0 direction (consolidation onto `tasks.shadowJar`) in favor of the Ktor-recommended API.
+- **JVM and Gradle versions now in the catalog.** `gradle = "9.5.0"` and `jvm = "17"` are tracked under `[versions]` in `gradle/libs.versions.toml`. `build.gradle.kts` reads `libs.versions.jvm.get().toInt()` for the toolchain; `Makefile` reads `gradle` from the catalog when running `upgrade-wrapper`.
+- **Catalog plugin alias renamed.** `versions` → `ben-manes-versions` to avoid the name collision with the `[versions]` table. Call site is `alias(libs.plugins.ben.manes.versions)`.
+
+### Upgrade Notes
+
+- Forks invoking `./gradlew uberjar` should switch to `./gradlew buildFatJar` (or use `make uberjar`).
+- Forks referencing `libs.plugins.versions` should rename to `libs.plugins.ben.manes.versions`.
+
+### Verification
+
+- `./gradlew buildFatJar` — produces `build/libs/server.jar` (~184 MB).
+- `./gradlew tasks` and `./gradlew help` resolve cleanly.
+- `make -n upgrade-wrapper` expands to `./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin`.
+
+---
+
 ## v1.7.0 — 2026-05-03
 
 A build-housekeeping release. No DSL or runtime behavior changes — existing `Content.kt` definitions compile and run unchanged.
@@ -36,7 +60,7 @@ A build-housekeeping release. No DSL or runtime behavior changes — existing `C
 ### Verification
 
 - `./gradlew --rerun-tasks check` — all challenge tests pass.
-- `./gradlew uberjar` — produces a runnable `build/libs/server.jar`.
+- `./gradlew buildFatJar` — produces a runnable `build/libs/server.jar`.
 - `./gradlew properties` — confirms `group=com.readingbat` and `version=1.7.0`.
 
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
   application
   alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.versions)
+  alias(libs.plugins.ben.manes.versions)
   alias(libs.plugins.ktor.plugin)
 }
 
@@ -23,25 +24,30 @@ dependencies {
 }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(libs.versions.jvm.get().toInt())
 }
+
+val cleanTask = tasks.named("clean")
+val buildTask = tasks.named("build")
 
 tasks.register("stage") {
-  dependsOn("clean", "build")
+  dependsOn(cleanTask, buildTask)
 }
 
-tasks.named("build") {
-  mustRunAfter("clean")
+buildTask {
+  mustRunAfter(cleanTask)
+}
+
+ktor {
+  fatJar {
+    archiveFileName = "server.jar"
+  }
 }
 
 tasks.shadowJar {
-  archiveFileName.set("server.jar")
   isZip64 = true
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  exclude("META-INF/*.SF")
-  exclude("META-INF/*.DSA")
-  exclude("META-INF/*.RSA")
-  exclude("LICENSE*")
+  exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*")
 }
 
 tasks.test {
@@ -49,7 +55,7 @@ tasks.test {
 
   testLogging {
     events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
-    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    exceptionFormat = TestExceptionFormat.FULL
     showStandardStreams = false
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=1.7.0
+version=1.7.1
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
+gradle = "9.5.0"
+jvm = "17"
 kotest = "6.1.11"
 kotlin = "2.3.21"
 ktor = "3.4.3"
 logging = "8.0.02"
+ben-manes-versions = "0.54.0"
 readingbat = "3.1.5"
 utils = "2.8.2"
-versions = "0.54.0"
 
 [libraries]
 core-utils = { module = "com.pambrose.common-utils:core-utils", version.ref = "utils" }
@@ -29,6 +31,6 @@ testing = [
 ]
 
 [plugins]
+ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor-plugin = { id = "io.ktor.plugin", version.ref = "ktor" }
-versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ ReadingBat Template provides a starting point for educators to create their own 
 - Build: ./gradlew build -xtest
 - Run server: ./gradlew run
 - Run tests: ./gradlew --rerun-tasks check
-- Build fat JAR: ./gradlew uberjar
+- Build fat JAR: ./gradlew buildFatJar (outputs build/libs/server.jar)
 
 ## Key Files
 
@@ -21,7 +21,7 @@ ReadingBat Template provides a starting point for educators to create their own 
 - build.gradle.kts: Gradle build script (group/version live in gradle.properties)
 - gradle.properties: Project group and version
 - settings.gradle.kts: Repository configuration with FAIL_ON_PROJECT_REPOS enforcement
-- gradle/libs.versions.toml: Dependency version catalog with [bundles] testing group
+- gradle/libs.versions.toml: Dependency version catalog with [bundles] testing group; also tracks jvm and gradle versions consumed by build.gradle.kts and Makefile
 - CHANGELOG.md / RELEASE_NOTES.md: Release history and per-version notes
 - python/: Python challenge source files
 - src/main/java/: Java challenge source files
@@ -50,9 +50,9 @@ The repo property in Content.kt switches between GitHubRepo (production, reads f
 
 ## Tech Stack
 
-- Language: Kotlin (JVM 17)
+- Language: Kotlin (JVM 17, version sourced from libs.versions.toml)
 - Web framework: Ktor
 - Test framework: Kotest (StringSpec style, JUnit5 runner)
 - Build: Gradle 9.5.0 with version catalog (libs.versions.toml) and properties-driven version
-- Deployment: Heroku-compatible (system.properties, fat JAR via shadow plugin)
+- Deployment: Heroku-compatible (system.properties, fat JAR via Ktor plugin's buildFatJar task)
 - Current version: 1.7.0


### PR DESCRIPTION
## Summary

Build-housekeeping follow-ups to 1.7.0 — no DSL or runtime behavior changes.

- **Fix broken fat-jar target.** `make uberjar` (and the documented `./gradlew uberjar`) referenced a task that does not exist. The Makefile now invokes `./gradlew buildFatJar`; CLAUDE.md and llms.txt updated.
- **Single fat-jar config path.** Switched to Ktor's idiomatic `ktor { fatJar { archiveFileName = "server.jar" } }`; `tasks.shadowJar` now only carries the META-INF signature/license excludes (collapsed into one varargs call).
- **JVM/Gradle versions in the catalog.** `gradle = "9.5.0"` and `jvm = "17"` now live in `gradle/libs.versions.toml`. `build.gradle.kts` reads `libs.versions.jvm.get().toInt()`; the Makefile derives the Gradle version from the catalog via `sed`.
- **Catalog alias rename.** `versions` -> `ben-manes-versions` (the prior name collided with the `[versions]` table). Call site is `alias(libs.plugins.ben.manes.versions)`.
- **Misc.** Extracted repeated `"clean"`/`"build"` task-name strings to `cleanTask`/`buildTask` references; bumped version to 1.7.1; updated CHANGELOG / RELEASE_NOTES / CLAUDE.md / llms.txt.

## Upgrade Notes

- Forks invoking `./gradlew uberjar` should switch to `./gradlew buildFatJar` (or use `make uberjar`).
- Forks referencing `libs.plugins.versions` should rename to `libs.plugins.ben.manes.versions`.

## Test plan

- [x] `./gradlew help` resolves cleanly
- [x] `./gradlew tasks --all` lists `buildFatJar` and `shadowJar`
- [x] `./gradlew buildFatJar` produces `build/libs/server.jar` (~184 MB)
- [x] `make -n upgrade-wrapper` expands to `./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin`
- [x] `make -n uberjar` expands to `./gradlew buildFatJar`
- [ ] `./gradlew --rerun-tasks check` — challenge tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)