### PR TITLE
Run gradle wrapper twice in upgrade-wrapper target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ logs: ## Tail Heroku logs
 versioncheck: ## Check for dependency updates
 	./gradlew dependencyUpdates
 
+# Gradle's documented upgrade procedure: the first run rewrites
+# gradle-wrapper.properties using the *old* wrapper jar; the second run
+# regenerates the wrapper itself with the new version.
 upgrade-wrapper: _require-gradle-version ## Upgrade the Gradle wrapper to the version in libs.versions.toml
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
 
 _require-gradle-version:


### PR DESCRIPTION
## Summary
- Invoke `./gradlew wrapper` twice in the `upgrade-wrapper` Make target so the wrapper jar itself is regenerated with the new Gradle version, per Gradle's documented upgrade procedure
- Add an explanatory comment describing why both runs are needed

## Test plan
- [ ] Run `make upgrade-wrapper GRADLE_VERSION=<version>` and confirm both `gradle-wrapper.properties` and the wrapper jar are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)