### PR TITLE
Add GitHub Actions CI workflow on JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew --rerun-tasks check
+
+      - name: Lint (kotlinter + detekt)
+        run: ./gradlew lintKotlin detekt


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — the repo had no CI workflow previously.

## What it does
- **Triggers:** push and pull requests to `master`.
- **JDK:** Temurin **25** (`actions/setup-java@v4`), matching the project's JVM 25 toolchain.
- **Gradle:** `gradle/actions/setup-gradle@v4` for wrapper execution and build/configuration-cache caching.
- **Steps:**
  - `./gradlew --rerun-tasks check` — build + all challenge tests
  - `./gradlew lintKotlin detekt` — kotlinter + detekt

## Notes
- The workflow uses no untrusted `github.event.*` input; every `run:` is a static command, so there's no command/ref-injection surface.
- `check` already wires in `lintKotlin`/`detekt`, so the explicit lint step is mostly redundant but gives a clearly-labeled lint result in the CI log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)