### PR TITLE
Prepare 1.9.0 release: dep bumps and CI documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-07-26
+
+### Added
+
+- GitHub Actions CI workflow (`.github/workflows/ci.yml`). Runs on pushes and pull requests targeting `master`: checks out the repo, sets up Temurin JDK 25 and Gradle, runs `./gradlew --rerun-tasks check`, then `./gradlew lintKotlin detekt`.
+
+### Changed
+
+- Bumped dependencies: `readingbat-core` / `readingbat-kotest` 3.2.1 → 3.3.0, Kotlin 2.4.0 → 2.4.10, Kotest 6.2.1 → 6.2.3, `core-utils` 2.9.3 → 3.2.1, and Kotlinter 5.5.0 → 5.6.0.
+- Renamed the `[versions]` catalog key `ben-manes-versions` → `versions`. The plugin alias stays `ben-manes-versions`, so the `alias(libs.plugins.ben.manes.versions)` call site in `build.gradle.kts` is unchanged.
+
 ## [1.8.0] - 2026-07-03
 
 ### Added
@@ -87,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrades to Kotlin 2.1.0 / Ktor 3.0.1, `readingbat-core` 2.0.0, and various jar refreshes.
 
+[1.9.0]: https://github.com/readingbat/readingbat-template/compare/1.8.0...1.9.0
 [1.8.0]: https://github.com/readingbat/readingbat-template/compare/1.7.0...1.8.0
 [1.7.0]: https://github.com/readingbat/readingbat-template/compare/1.6.0...1.7.0
 [1.6.0]: https://github.com/readingbat/readingbat-template/releases/tag/1.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ Fat-jar output (`build/libs/server.jar`) is configured via the `ktor { fatJar { 
 - Kotlinter (ktlint) and detekt are wired in via Gradle plugins (`org.jmailen.kotlinter` and `dev.detekt`). Run them together with `make lint`; auto-fix ktlint with `make format`.
 - Gradle's configuration cache is enabled (`org.gradle.configuration-cache=true` in `gradle.properties`) — keep new build logic configuration-cache-compatible.
 
+## Continuous Integration
+
+`.github/workflows/ci.yml` runs on pushes and pull requests targeting `master`. It installs Temurin JDK 25, sets up Gradle, then runs two steps:
+
+1. `./gradlew --rerun-tasks check`
+2. `./gradlew lintKotlin detekt`
+
+Both must pass, so run `make tests` and `make lint` locally before pushing — a formatting violation fails CI just as a test failure does.
+
 ## DSL Conventions
 
 - Java challenge return types are inferred from source code; Python and Kotlin challenges require explicit `returnType` (e.g., `BooleanType`, `StringType`, `IntType`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Kotlin](https://img.shields.io/badge/%20language-Kotlin-red.svg)](https://kotlinlang.org/)
+[![CI](https://github.com/readingbat/readingbat-template/actions/workflows/ci.yml/badge.svg)](https://github.com/readingbat/readingbat-template/actions/workflows/ci.yml)
 
 # ReadingBat Template
 
@@ -53,6 +54,12 @@ A `Makefile` is also provided with shorthand targets (`make build`, `make run`, 
 
 > Project metadata (`group`, `version`) is set in [`gradle.properties`](./gradle.properties).
 > Dependency versions and the `testing` bundle are defined in [`gradle/libs.versions.toml`](./gradle/libs.versions.toml).
+
+## Continuous Integration
+
+[`.github/workflows/ci.yml`](./.github/workflows/ci.yml) runs on every push and pull request to `master`.
+It builds and tests on Temurin JDK 25 (`./gradlew --rerun-tasks check`), then runs the linters
+(`./gradlew lintKotlin detekt`). Run `make tests` and `make lint` locally to catch failures before pushing.
 
 ## Content Specification
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,50 @@
 # Release Notes
 
+## v1.9.0 — 2026-07-26
+
+A dependency-refresh and CI release on top of 1.8.0. There are no DSL, content, or runtime source changes — existing `Content.kt` definitions compile and run unchanged, and the build still targets **JDK 25**.
+
+### Highlights
+
+- **GitHub Actions CI.** `.github/workflows/ci.yml` runs on pushes and pull requests targeting `master`. It checks out the repo, installs Temurin JDK 25, sets up Gradle via `gradle/actions/setup-gradle@v4`, runs `./gradlew --rerun-tasks check`, then runs `./gradlew lintKotlin detekt`. Lint and static analysis are now enforced on every PR rather than by convention.
+- **readingbat-core / readingbat-kotest 3.2.1 → 3.3.0.** No call-site changes were required; `correctAnswers()` remains a suspend function as of 3.2.0.
+- **core-utils 2.9.3 → 3.2.1.** A major-version bump of a library the template uses directly — `FileSystemSource`, `GitHubRepo`, and `OwnerType.Organization` in `Content.kt`, and `toDoubleQuoted` in `ContentTests.kt`. All four call sites compile unchanged against 3.x.
+- **Kotlin 2.4.0 → 2.4.10, Kotest 6.2.1 → 6.2.3, Kotlinter 5.5.0 → 5.6.0.**
+- **Catalog version key renamed.** `[versions] ben-manes-versions` → `versions`. The plugin alias remains `ben-manes-versions`, so `alias(libs.plugins.ben.manes.versions)` in `build.gradle.kts` is unchanged. This affects only the `version.ref` inside `libs.versions.toml`.
+
+### Dependencies
+
+| Library          | Version       |
+|------------------|---------------|
+| Kotlin           | 2.4.10        |
+| Ktor             | 3.5.1         |
+| Kotest           | 6.2.3         |
+| readingbat-core  | 3.3.0         |
+| core-utils       | 3.2.1         |
+| kotlin-logging   | 8.0.4         |
+| detekt           | 2.0.0-alpha.5 |
+| kotlinter        | 5.6.0         |
+| Gradle           | 9.6.1         |
+| JDK toolchain    | 25            |
+
+### Upgrade Notes
+
+- No source changes are required for forks that track this template — this release touches only `.github/workflows/ci.yml`, `gradle/libs.versions.toml`, and `gradle.properties`.
+- Forks that add their own `[versions] ben-manes-versions` entry should rename the key to `versions` (or leave theirs alone and keep their own `version.ref`).
+- Forks with custom code against `core-utils` 2.x should re-verify against 3.x; the template's own usage needed no changes, but 3.0.0 is a major release.
+- JDK 25 remains required, unchanged from 1.8.0.
+
+### Verification
+
+- `./gradlew --rerun-tasks check` — BUILD SUCCESSFUL; all three `ContentTests` specs pass (`Test all challenges`, `Test with correct answers`, `Test individual challenges`).
+- `./gradlew buildFatJar` — BUILD SUCCESSFUL; produces `build/libs/server.jar`.
+- `./gradlew lintKotlin detekt` — both checks run cleanly on `master`.
+- `build/libs/readingbat-template-1.9.0.jar` confirms the `gradle.properties` version bump took effect.
+
+**Full Changelog:** https://github.com/readingbat/readingbat-template/compare/1.8.0...1.9.0
+
+---
+
 ## v1.8.0 — 2026-07-03
 
 A linting and toolchain-modernization release on top of 1.7.0. The content DSL is unchanged, but the project now targets **JDK 25** and picks up **readingbat-core 3.2.1**, which adjusts one test call site.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readingbat
-version=1.8.0
+version=1.9.0
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-ben-manes-versions = "0.54.0"
 detekt = "2.0.0-alpha.5"
 gradle-wrapper = "9.6.1"
 jvm = "25"
-kotest = "6.2.2"
-kotlin = "2.4.0"
+kotest = "6.2.3"
+kotlin = "2.4.10"
 kotlinter = "5.6.0"
 ktor = "3.5.1"
 logging = "8.0.4"
-readingbat = "3.2.1"
-utils = "3.0.0"
+readingbat = "3.3.0"
+utils = "3.2.1"
+versions = "0.54.0"
 
 [libraries]
 core-utils = { module = "com.pambrose.common-utils:core-utils", version.ref = "utils" }
@@ -33,7 +33,7 @@ testing = [
 ]
 
 [plugins]
-ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
+ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,7 @@ ReadingBat Template provides a starting point for educators to create their own 
 - gradle/libs.versions.toml: Dependency version catalog with [bundles] testing group; also tracks jvm, gradle-wrapper, detekt, and kotlinter versions consumed by build.gradle.kts and Makefile
 - .editorconfig: Project-wide formatting (UTF-8, LF, 2-space indent, 120-char max) and ktlint rule overrides
 - Makefile: Shorthand targets (build/run/tests/lint/format/detekt/uberjar/etc.) with self-documenting `make help`
+- .github/workflows/ci.yml: GitHub Actions CI — builds and tests on Temurin JDK 25, then runs lintKotlin and detekt
 - CHANGELOG.md / RELEASE_NOTES.md: Release history and per-version notes
 - python/: Python challenge source files
 - src/main/java/: Java challenge source files
@@ -60,6 +61,7 @@ The repo property in Content.kt switches between GitHubRepo (production, reads f
 - Test framework: Kotest (StringSpec style, JUnit5 runner)
 - Build: Gradle 9.6.1 with version catalog (libs.versions.toml), properties-driven version, and configuration cache enabled
 - Static analysis: detekt (`dev.detekt`) and Kotlinter / ktlint (`org.jmailen.kotlinter`)
+- CI: GitHub Actions (.github/workflows/ci.yml) on pushes and PRs to master
 - Deployment: Runnable fat JAR via the Ktor plugin's buildFatJar task (build/libs/server.jar)
-- readingbat-core: 3.2.1
-- Current version: 1.8.0
+- readingbat-core: 3.3.0
+- Current version: 1.9.0


### PR DESCRIPTION
## Summary

Bumps the project version to `1.9.0` and records the release across the documentation set. No DSL, content, or runtime source changes — this touches only the version catalog, `gradle.properties`, and docs.

## Dependency changes

Net versus the `1.8.0` tag:

| Library | 1.8.0 | 1.9.0 |
|---|---|---|
| readingbat-core / readingbat-kotest | 3.2.1 | 3.3.0 |
| Kotlin | 2.4.0 | 2.4.10 |
| Kotest | 6.2.1 | 6.2.3 |
| core-utils | 2.9.3 | 3.2.1 |
| Kotlinter | 5.5.0 | 5.6.0 |

`core-utils` is a major bump of a library used directly by this template — `FileSystemSource`, `GitHubRepo`, and `OwnerType.Organization` in `Content.kt`, and `toDoubleQuoted` in `ContentTests.kt`. All four call sites compile unchanged against 3.x.

Also renames the `[versions]` catalog key `ben-manes-versions` → `versions`. The plugin alias remains `ben-manes-versions`, so `alias(libs.plugins.ben.manes.versions)` in `build.gradle.kts` is unchanged.

> [!NOTE]
> This partially reverses a 1.8.0 change, which renamed the key the other direction to avoid colliding with the `[versions]` table name. Nothing breaks either way, but worth a look if that revert was unintentional.

## Documentation

- **CHANGELOG.md** — 1.9.0 section plus the compare link
- **RELEASE_NOTES.md** — `v1.9.0` highlights, dependency table, upgrade notes, verification results
- **CLAUDE.md** / **README.md** — new "Continuous Integration" sections documenting the GitHub Actions workflow added in 8346cac
- **README.md** — CI status badge
- **llms.txt** — refreshed `readingbat-core` and current-version values, CI noted in Key Files and Tech Stack

## Test plan

Run locally on JDK 25 before the docs were written:

- [x] `./gradlew --rerun-tasks check` — BUILD SUCCESSFUL; all three `ContentTests` specs pass
- [x] `./gradlew buildFatJar` — BUILD SUCCESSFUL; produces `build/libs/server.jar`
- [x] `./gradlew lintKotlin detekt` — both clean
- [x] `build/libs/readingbat-template-1.9.0.jar` confirms the version bump took effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)